### PR TITLE
Improve numerical stability of trie mass computation

### DIFF
--- a/genlm/bytes/byte_lm/trie_state.py
+++ b/genlm/bytes/byte_lm/trie_state.py
@@ -214,8 +214,11 @@ class LazyTrieState:
         """
         if self._mass is None:
             logp_next = await self.lm_state.logp_next()
-            log_mass = await self.trie.weight_sum(torch.exp(logp_next), self.mode)
-            mass = torch.log(log_mass)
+            shift = logp_next.max()  # max-shift trick to avoid underflow in exp
+            shifted_mass = await self.trie.weight_sum(
+                torch.exp(logp_next - shift), self.mode
+            )
+            mass = torch.log(shifted_mass) + shift.to(device=shifted_mass.device)
             self._mass = mass.cpu().numpy()
         return self
 


### PR DESCRIPTION
## Summary

This PR improves numerical stability in `LazyTrieState.materialize()` by applying the max-shift trick before exponentiating next-token log probabilities.

## Motivation

The previous implementation computed trie masses directly from:

```python
torch.exp(logp_next)
```

When some log probabilities are very small, this exponentiation can underflow to zero before trie mass aggregation. As a result, reachable trie nodes may receive zero mass, which can later become `-inf` after taking `torch.log`.

## Change

This PR subtracts the maximum value of `logp_next` before exponentiation, and then adds the shift back after trie mass aggregation:

```python
shift = logp_next.max()
shifted_mass = await self.trie.weight_sum(
    torch.exp(logp_next - shift), self.mode
)
mass = torch.log(shifted_mass) + shift.to(device=shifted_mass.device)
```

This keeps the computation mathematically equivalent while reducing unnecessary underflow during exponentiation.

The shift scalar is also moved to `shifted_mass.device` before addition, making the final operation safe when the LM output and trie computation are on different devices.

## Tests

No tests were added or modified.

The following existing tests pass:

```bash
pytest tests/test_trie.py
pytest tests/test_beam.py
pytest tests/test_healing.py
```